### PR TITLE
Merging jeelabs/master to sanbee/jeelib master

### DIFF
--- a/Ports.cpp
+++ b/Ports.cpp
@@ -1110,7 +1110,7 @@ void Sleepy::watchdogInterrupts (char mode) {
         mode ^= bit(3) | bit(WDP3);
     // pre-calculate the WDTCSR value, can't do it inside the timed sequence
     // we only generate interrupts, no reset
-    byte wdtcsr = mode >= 0 ? bit(WDIE) | mode : backupMode;
+    byte wdtcsr = mode >= 0 ? ( bit(WDE) & WDTCSR ) | bit(WDIE) | mode : backupMode;
     if(mode>=0) backupMode = WDTCSR;
     MCUSR &= ~(1<<WDRF);
     ATOMIC_BLOCK(ATOMIC_FORCEON) {

--- a/Ports.cpp
+++ b/Ports.cpp
@@ -1168,7 +1168,7 @@ byte Sleepy::loseSomeTime (word msecs) {
         msleft -= halfms;
     }
     // adjust the milli ticks, since we will have missed several
-#if defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny85__) || defined (__AVR_ATtiny44__) || defined (__AVR_ATtiny45__)
+#if defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny85__) || defined (__AVR_ATtiny44__) || defined (__AVR_ATtiny45__) || defined (__AVR_ATtiny88__)
     extern volatile unsigned long millis_timer_millis;
     millis_timer_millis += msecs - msleft;
 #else

--- a/examples/RF12/roomNode/roomNode.ino
+++ b/examples/RF12/roomNode/roomNode.ino
@@ -101,7 +101,7 @@ struct {
             byte f = value;
             if (lastOn > 0)
                 ATOMIC_BLOCK(ATOMIC_RESTORESTATE) {
-                    if (millis() - lastOn < 1000 * PIR_HOLD_TIME)
+                    if (millis() - lastOn < (uint32_t)(1000 * PIR_HOLD_TIME))
                         f = 1;
                 }
             return f;


### PR DESCRIPTION
This includes defined(__AVR_ATtiny88__) in Sleepy::loseSomeTime() plus another change in Sleepy::loseSomeTime() that frankly I don't understand.

